### PR TITLE
WARNING `attenuation: 11db` is deprecated

### DIFF
--- a/devices/Under_Development/v2.yaml
+++ b/devices/Under_Development/v2.yaml
@@ -144,7 +144,7 @@ sensor:
     pin: GPIO${battery_adc_pin}
     name: "Battery Voltage"
     id: battery_voltage
-    attenuation: 11db
+    attenuation: auto
     accuracy_decimals: 2
     update_interval: 1s
     unit_of_measurement: "V"


### PR DESCRIPTION
The attenuation configuration option for ESP32 adc sensors has had a deprecation in the underlying ESP-IDF framework with the 11dB option. The value to replace 11dB with is 12dB. There are no functionality changes otherwise. There will be a warning in the logs when installing if you are using 11dB and it will be removed in ESPHome 2024.8.0.