### PR TITLE
Add bluetooth proxy support

### DIFF
--- a/devices/Spotpear Balls/Ball_v2.yaml
+++ b/devices/Spotpear Balls/Ball_v2.yaml
@@ -27,6 +27,8 @@ substitutions:
   displaymodel: "GC9A01A" # GC9A01A (Ball v2 & Puck) or ST7789V (Muma)
   invertcolors: "true" # GC9A01A/ST7789V (Ball v2 & Muma & Puck) "true"
 
+  bluetooth_proxy: false
+
 ##################################################################################################################################################
 
   # Hardware v2 pin mappings
@@ -154,6 +156,11 @@ wifi:
     - script.execute: draw_display
   on_disconnect:
     - script.execute: draw_display
+
+esp32_ble_tracker:
+
+bluetooth_proxy:
+  active: ${bluetooth_proxy}
 
 captive_portal:
 


### PR DESCRIPTION
I've added the code to be able to use the Spotpear Ball v2 as a bluetooth proxy.

As there is one in every room, this allows me to use the `Bermuda BLE Trilateration` integration for a better device tracking to control automations.

The proxy is disabled by default. Set `bluetooth_proxy` to `true` to enable the functionality.

@RealDeco 
I don't know the other satellite devices. But if they are also have built in bluetooth, this configuration can be adopted to them.