### PR TITLE
muma: fix timer progress bar

### DIFF
--- a/devices/Spotpear Muma/Muma.yaml
+++ b/devices/Spotpear Muma/Muma.yaml
@@ -504,14 +504,14 @@ script:
           id(check_if_timers).execute();
           if (id(global_is_timer_active)){
             id(fetch_first_active_timer).execute();
-            int active_pixels = round( 320 * id(global_first_active_timer).seconds_left / max(id(global_first_active_timer).total_seconds , static_cast<uint32_t>(1)) );
+            int active_pixels = round( 240 * id(global_first_active_timer).seconds_left / max(id(global_first_active_timer).total_seconds , static_cast<uint32_t>(1)) );
             if (active_pixels > 0){
               id(s3_box_lcd).filled_rectangle(0 , 225 , 240 , 15 , Color::WHITE );
               id(s3_box_lcd).filled_rectangle(0 , 226 , active_pixels , 13 , id(active_timer_color) );
             }
           } else if (id(global_is_timer)){
             id(fetch_first_timer).execute();
-            int active_pixels = round( 320 * id(global_first_timer).seconds_left / max(id(global_first_timer).total_seconds , static_cast<uint32_t>(1)));
+            int active_pixels = round( 240 * id(global_first_timer).seconds_left / max(id(global_first_timer).total_seconds , static_cast<uint32_t>(1)));
             if (active_pixels > 0){
               id(s3_box_lcd).filled_rectangle(0 , 225 , 240 , 15 , Color::WHITE );
               id(s3_box_lcd).filled_rectangle(0 , 226 , active_pixels , 13 , id(paused_timer_color) );


### PR DESCRIPTION
Correct the `active_pixels` formula to account for the muma's 240px screen.

Without it, the first third of the timer's runtime keeps displaying a fully green progress bar.